### PR TITLE
Add module method for creating enum with bracket syntax

### DIFF
--- a/lib/enum.rb
+++ b/lib/enum.rb
@@ -2,3 +2,11 @@ require 'enum/version'
 require 'enum/token_not_found_error'
 require 'enum/base'
 require 'enum/predicates'
+
+module Enum
+  def self.[](*ary)
+    Class.new(Base) do
+      values(*ary)
+    end
+  end
+end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -170,4 +170,12 @@ describe Enum::Base do
       end
     end
   end
+
+  describe Room::COLORS do
+    describe '#all' do
+      it 'returns the defined values in order of their definition' do
+        assert_equal ["yellow", "orange", "blue"], Room::COLORS.all
+      end
+    end
+  end
 end

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -20,4 +20,6 @@ module Room
   class Side < Enum::Base
     values :left, :right
   end
+
+  COLORS = Enum[:yellow, :orange, :blue]
 end


### PR DESCRIPTION
Set-like sugar syntax for creating `Enum`s without having to subclass explicitly.