### PR TITLE
Ruby 3 keyword arguments support

### DIFF
--- a/lib/enum/base.rb
+++ b/lib/enum/base.rb
@@ -66,7 +66,7 @@ module Enum
       def translate(token, options = {})
         I18n.t(token, scope: "enum.#{self}", exception_handler: proc do
           if superclass == Enum::Base
-            I18n.t(token, options.merge(scope: "enum.#{self}"))
+            I18n.t(token, **options.merge(scope: "enum.#{self}"))
           else
             superclass.translate(token, exception_handler: proc do
               I18n.t(token, scope: "enum.#{self}")


### PR DESCRIPTION
The implicit conversion of keyword arguments and Hash doesn't work anymore with Ruby 3